### PR TITLE
Use Get-Date instead of [datetime]::UtcNow

### DIFF
--- a/modules/SATOCerts.ps1
+++ b/modules/SATOCerts.ps1
@@ -18,8 +18,8 @@ function Create-JwtHeaderPayload {
     $audience = "https://login.microsoftonline.com/$TenantID/oauth2/v2.0/token"
 
     
-    $StartDate = [datetime]::UtcNow.AddSeconds(-10)
-    $EndDate = [datetime]::UtcNow.AddMinutes(5)
+    $StartDate = (Get-Date).AddSeconds(-10)
+    $EndDate = (Get-Date).AddMinutes(5)
     $JWTExpiration = [math]::Round(($EndDate - [datetime]"1970-01-01T00:00:00Z").TotalSeconds)
     $NotBefore = [math]::Round(($StartDate - [datetime]"1970-01-01T00:00:00Z").TotalSeconds)
 

--- a/modules/SATOCerts.ps1
+++ b/modules/SATOCerts.ps1
@@ -18,10 +18,10 @@ function Create-JwtHeaderPayload {
     $audience = "https://login.microsoftonline.com/$TenantID/oauth2/v2.0/token"
 
     
-    $StartDate = (Get-Date).AddSeconds(-10)
-    $EndDate = (Get-Date).AddMinutes(5)
-    $JWTExpiration = [math]::Round(($EndDate - [datetime]"1970-01-01T00:00:00Z").TotalSeconds)
-    $NotBefore = [math]::Round(($StartDate - [datetime]"1970-01-01T00:00:00Z").TotalSeconds)
+    $StartDate = [datetime]::UtcNow.AddSeconds(-10)
+    $EndDate = [datetime]::UtcNow.AddMinutes(5)
+    $JWTExpiration = [math]::Round(($EndDate - ([datetime]"1970-01-01T00:00:00Z").ToUniversalTime()).TotalSeconds)
+    $NotBefore = [math]::Round(($StartDate - ([datetime]"1970-01-01T00:00:00Z").ToUniversalTime()).TotalSeconds)
 
     
     $jwtHeader = @{


### PR DESCRIPTION
Creating the JWT in `Create-JwtHeaderPayload` might fail if you're not in UTC timezone.
Replacing `[datetime]::UtcNow` with `(Get-Date)` appears to solve that problem

This solves #1

```json
 {"error":"invalid_client","error_description":"AADSTS700024: Client assertion is not within its valid time range. Current time: 2024-12-07T12:09:18.3149355Z, assertion valid from
1970-01-01T00:00:00.0000000Z, expiry time of assertion 2024-12-07T11:14:18.0000000Z....." }
```


